### PR TITLE
refactor: migrate reinstall_local.bat from pip to uv

### DIFF
--- a/tools/reinstall_local.bat
+++ b/tools/reinstall_local.bat
@@ -15,37 +15,35 @@ popd
 
 set "VENV_DIR=!PROJECT_DIR!\.venv"
 set "VENV_SCRIPTS=!VENV_DIR!\Scripts"
-set "VENV_PIP=!VENV_SCRIPTS!\pip.exe"
+echo [0/6] Checking Python environment...
 
-echo [0/5] Checking Python environment...
+REM Check if uv is available
+where uv >nul 2>&1
+if !ERRORLEVEL! NEQ 0 (
+    echo [FAIL] uv not found. Install it: pip install uv
+    exit /b 1
+)
+echo [OK] uv found
 
 REM Check if local .venv exists
 if not exist "!VENV_SCRIPTS!\activate.bat" (
     echo Local virtual environment not found at !VENV_DIR!
-    python -m venv .venv
+    uv venv .venv
     echo Local virtual environment created at !VENV_DIR!
 )
-
-if not exist "!VENV_PIP!" (
-    echo [FAIL] pip.exe not found in !VENV_SCRIPTS!
-    echo The virtual environment may be corrupted. Recreate it: python -m venv .venv
-    exit /b 1
-)
-
-echo [OK] Using venv pip: !VENV_PIP!
 echo.
 
-echo [1/5] Uninstalling existing packages...
+echo [1/6] Uninstalling existing packages...
 REM Note: mcp-config is uninstalled here but will be automatically reinstalled
 REM as a dependency when mcp-tools-py is installed (see pyproject.toml)
-"!VENV_PIP!" uninstall mcp-tools-py mcp-config mcp-workspace -y
+uv pip uninstall mcp-tools-py mcp-config mcp-workspace --python "!VENV_SCRIPTS!\python.exe" 2>nul
 echo [OK] Packages uninstalled
 
 echo.
-echo [2/5] Installing mcp-coder from git...
+echo [2/6] Installing mcp-coder from git...
 REM Install mcp-coder FIRST so that its dependency on mcp-tools-py gets
 REM overridden by our local editable install in the next step.
-"!VENV_PIP!" install "mcp-coder @ git+https://github.com/MarcusJellinghaus/mcp_coder.git"
+uv pip install "mcp-coder @ git+https://github.com/MarcusJellinghaus/mcp_coder.git" --python "!VENV_SCRIPTS!\python.exe"
 if !ERRORLEVEL! NEQ 0 (
     echo [FAIL] mcp-coder installation failed!
     exit /b 1
@@ -53,11 +51,11 @@ if !ERRORLEVEL! NEQ 0 (
 echo [OK] mcp-coder installed
 
 echo.
-echo [3/5] Installing mcp-tools-py in development mode (takes priority)...
+echo [3/6] Installing mcp-tools-py in development mode (takes priority)...
 REM Editable install AFTER mcp-coder so this local project takes priority
 REM over whatever version mcp-coder pulled as a dependency.
 pushd "!PROJECT_DIR!"
-"!VENV_PIP!" install -e ".[dev]"
+uv pip install -e ".[dev]" --python "!VENV_SCRIPTS!\python.exe"
 if !ERRORLEVEL! NEQ 0 (
     echo [FAIL] Installation failed!
     popd
@@ -67,7 +65,16 @@ popd
 echo [OK] Package and dev dependencies installed
 
 echo.
-echo [4/5] Verifying CLI entry points in venv...
+echo [4/6] Installing LangChain and MLflow dependencies...
+uv pip install langchain langchain-anthropic mlflow --python "!VENV_SCRIPTS!\python.exe"
+if !ERRORLEVEL! NEQ 0 (
+    echo [FAIL] LangChain/MLflow installation failed!
+    exit /b 1
+)
+echo [OK] langchain, langchain-anthropic, mlflow installed
+
+echo.
+echo [5/6] Verifying CLI entry points in venv...
 
 if not exist "!VENV_SCRIPTS!\mcp-tools-py.exe" (
     echo [FAIL] mcp-tools-py.exe not found in !VENV_SCRIPTS!
@@ -91,7 +98,7 @@ if not exist "!VENV_SCRIPTS!\mcp-coder.exe" (
 echo [OK] mcp-coder.exe found in !VENV_SCRIPTS!
 
 echo.
-echo [5/5] Verifying CLI functionality...
+echo [6/6] Verifying CLI functionality...
 "!VENV_SCRIPTS!\mcp-tools-py.exe" --help >nul 2>&1
 if !ERRORLEVEL! NEQ 0 (
     echo [FAIL] mcp-tools-py CLI verification failed!


### PR DESCRIPTION
## Summary
- Migrate `reinstall_local.bat` from `pip` to `uv` for faster dependency management
- Add `uv` availability check with clear error message
- Add LangChain and MLflow dependency installation step (step 4/6)

## Test plan
- [ ] Verify `uv` is detected correctly when installed
- [ ] Verify clear error message when `uv` is not installed
- [ ] Run full reinstall script and confirm all steps complete successfully