### PR TITLE
chore(config): rename from-github to install-from-github

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -121,7 +121,7 @@ ignore_missing_imports = true
 #        as documentation: f-strings in logging calls are acceptable for readability
 disable = ["W", "C", "R", "W1203"]
 
-[tool.mcp-coder.from-github]
+[tool.mcp-coder.install-from-github]
 # Installed WITH deps (leaves — picks up new external deps)
 packages = [
     "mcp-config-tool @ git+https://github.com/MarcusJellinghaus/mcp-config.git",


### PR DESCRIPTION
## Summary
- Rename `[tool.mcp-coder.from-github]` → `[tool.mcp-coder.install-from-github]` in `pyproject.toml`
- Aligns with upstream mcp_coder rename (MarcusJellinghaus/mcp_coder#684)

## Test plan
- [ ] Verify `mcp-coder` reads the new config section correctly
- [ ] Confirm no code in this repo references the old key

Closes #142