### PR TITLE
docs(claude): add read-only gh commands to approved Bash list

### DIFF
--- a/.claude/Claude.md
+++ b/.claude/Claude.md
@@ -157,7 +157,7 @@ git diff  # Should show formatting changes if any
 - Stage the formatted files
 - Then commit
 
-**ALLOWED git operations via Bash tool:**
+**ALLOWED git/gh operations via Bash tool:**
 
 ```
 git status
@@ -165,6 +165,9 @@ git diff
 git log
 git fetch
 git ls-tree
+gh issue view (read-only)
+gh pr view (read-only)
+gh run view (read-only)
 ```
 
 **⚠️ Bash discipline (applies to subagents too):**


### PR DESCRIPTION
## Summary
- Adds `gh issue view`, `gh pr view`, `gh run view` to the approved Bash commands in CLAUDE.md
- Aligns documentation with `settings.local.json` which already permits these commands
- Prevents unnecessary hesitation when Claude needs to read GitHub data

## Test plan
- [x] Verify CLAUDE.md renders correctly
- [x] Confirm entries match `settings.local.json` allow list