### PR TITLE
feat(mcp_tools_py): add __main__ entry point

### DIFF
--- a/src/mcp_tools_py/__main__.py
+++ b/src/mcp_tools_py/__main__.py
@@ -1,0 +1,5 @@
+"""Allow running via `python -m mcp_tools_py`."""
+
+from mcp_tools_py.main import main
+
+main()


### PR DESCRIPTION
## Summary
Adds a `__main__.py` module to enable running the package directly via `python -m mcp_tools_py`.

## Changes
- Add `__main__.py` that imports and calls `main()` from `mcp_tools_py.main`