### PR TITLE
fix(uv): pin mcp-tools-py self-reference to local path

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,7 +123,12 @@ jobs:
           python-version: "3.11"
 
       - name: Install dependencies
-        run: uv pip install --system ".[dev]"
+        run: uv sync --extra dev
+
+      - name: Activate venv
+        run: |
+          echo "VIRTUAL_ENV=$GITHUB_WORKSPACE/.venv" >> $GITHUB_ENV
+          echo "$GITHUB_WORKSPACE/.venv/bin" >> $GITHUB_PATH
 
       - name: Environment info
         run: |
@@ -145,10 +150,9 @@ jobs:
         uses: astral-sh/setup-uv@v7
 
       - name: Check file sizes
-        # mcp-coder is run via uvx in an isolated environment.
-        # --with . ensures uvx uses THIS branch's mcp_tools_py instead of
-        # whatever version mcp_coder would resolve as a transitive dependency.
-        run: uvx --from "git+https://github.com/MarcusJellinghaus/mcp_coder.git" --with . mcp-coder check file-size --max-lines 750 --allowlist-file .large-files-allowlist
+        # mcp-coder is run via uvx in an isolated environment. The check walks the
+        # filesystem only; it does not import mcp_tools_py, so no --with . is needed.
+        run: uvx --from "git+https://github.com/MarcusJellinghaus/mcp_coder.git" mcp-coder check file-size --max-lines 750 --allowlist-file .large-files-allowlist
 
   # Architecture and code quality checks (PR only)
   architecture:
@@ -175,7 +179,12 @@ jobs:
           python-version: "3.11"
 
       - name: Install dependencies
-        run: uv pip install --system ".[dev]"
+        run: uv sync --extra dev
+
+      - name: Activate venv
+        run: |
+          echo "VIRTUAL_ENV=$GITHUB_WORKSPACE/.venv" >> $GITHUB_ENV
+          echo "$GITHUB_WORKSPACE/.venv/bin" >> $GITHUB_PATH
 
       - name: Environment info
         run: |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -149,7 +149,12 @@ where = ["src"]
 [tool.setuptools.package-data]
 "*" = ["py.typed"]
 
+# mcp-coder's own [tool.uv.sources] maps mcp-tools-py to a git URL. When uv
+# builds mcp-coder from git, that mapping leaks into resolution and conflicts
+# with the local editable install of this project. Pinning the self-source to
+# "." here is intended to win over the transitive claim under `uv sync`.
 [tool.uv.sources]
+mcp-tools-py = { path = ".", editable = true }
 mcp-config-tool = { git = "https://github.com/MarcusJellinghaus/mcp-config.git" }
 mcp-coder-utils = { git = "https://github.com/MarcusJellinghaus/mcp-coder-utils.git" }
 mcp-workspace = { git = "https://github.com/MarcusJellinghaus/mcp-workspace.git" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -149,6 +149,11 @@ where = ["src"]
 [tool.setuptools.package-data]
 "*" = ["py.typed"]
 
+[tool.uv]
+# Break the self-referential cycle: mcp-coder declares mcp-tools-py via git URL,
+# but this project IS mcp-tools-py. Strip the URL constraint so the local install wins.
+override-dependencies = ["mcp-tools-py"]
+
 [tool.uv.sources]
 mcp-tools-py = { path = ".", editable = true }
 mcp-config-tool = { git = "https://github.com/MarcusJellinghaus/mcp-config.git" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -150,11 +150,32 @@ where = ["src"]
 "*" = ["py.typed"]
 
 # mcp-coder's own [tool.uv.sources] maps mcp-tools-py to a git URL. When uv
-# builds mcp-coder from git that mapping leaks into resolution and conflicts
-# with the root install of this project. Strip the URL constraint so the
-# root install (under `uv sync`) satisfies the now-unpinned requirement.
-[tool.uv]
-override-dependencies = ["mcp-tools-py"]
+# builds mcp-coder from git, that mapping leaks into resolution and conflicts
+# with the root install of this project. Override mcp-coder's declared deps
+# locally to drop the self-reference (sibling-compatibility testing is still
+# preserved — the other deps are mirrored verbatim from mcp-coder's main).
+[[tool.uv.dependency-metadata]]
+name = "mcp-coder"
+requires-dist = [
+    "claude-code-sdk",
+    "GitPython>=3.1.0",
+    "structlog>=23.2.0",
+    "python-json-logger>=3.3.0",
+    "pyperclip>=1.8.2",
+    "black>=23.0.0",
+    "isort>=5.12.0",
+    "mcp-workspace",
+    "mcp-coder-utils",
+    "PyGithub>=1.59.0",
+    "python-jenkins>=1.8.0",
+    "requests>=2.28.0",
+    "psutil>=5.9.0",
+    "tabulate>=0.9.0",
+    "textual>=1.0.0",
+    "truststore>=0.9.0",
+    "pywin32>=306; sys_platform == 'win32'",
+    "python-frontmatter>=1.0.0",
+]
 
 [tool.uv.sources]
 mcp-config-tool = { git = "https://github.com/MarcusJellinghaus/mcp-config.git" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -150,6 +150,7 @@ where = ["src"]
 "*" = ["py.typed"]
 
 [tool.uv.sources]
+mcp-tools-py = { path = ".", editable = true }
 mcp-config-tool = { git = "https://github.com/MarcusJellinghaus/mcp-config.git" }
 mcp-coder-utils = { git = "https://github.com/MarcusJellinghaus/mcp-coder-utils.git" }
 mcp-workspace = { git = "https://github.com/MarcusJellinghaus/mcp-workspace.git" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -151,8 +151,13 @@ where = ["src"]
 
 # mcp-coder's own [tool.uv.sources] maps mcp-tools-py to a git URL. When uv
 # builds mcp-coder from git, that mapping leaks into resolution and conflicts
-# with the local editable install of this project. Pinning the self-source to
-# "." here is intended to win over the transitive claim under `uv sync`.
+# with the local editable install of this project. The self-source pins the
+# resolution to ".", and override-dependencies strips the URL constraint so
+# uv does not error on the transitive git claim — under `uv sync` (project
+# mode) the root install satisfies the now-unpinned requirement.
+[tool.uv]
+override-dependencies = ["mcp-tools-py"]
+
 [tool.uv.sources]
 mcp-tools-py = { path = ".", editable = true }
 mcp-config-tool = { git = "https://github.com/MarcusJellinghaus/mcp-config.git" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -150,16 +150,13 @@ where = ["src"]
 "*" = ["py.typed"]
 
 # mcp-coder's own [tool.uv.sources] maps mcp-tools-py to a git URL. When uv
-# builds mcp-coder from git, that mapping leaks into resolution and conflicts
-# with the local editable install of this project. The self-source pins the
-# resolution to ".", and override-dependencies strips the URL constraint so
-# uv does not error on the transitive git claim — under `uv sync` (project
-# mode) the root install satisfies the now-unpinned requirement.
+# builds mcp-coder from git that mapping leaks into resolution and conflicts
+# with the root install of this project. Strip the URL constraint so the
+# root install (under `uv sync`) satisfies the now-unpinned requirement.
 [tool.uv]
 override-dependencies = ["mcp-tools-py"]
 
 [tool.uv.sources]
-mcp-tools-py = { path = ".", editable = true }
 mcp-config-tool = { git = "https://github.com/MarcusJellinghaus/mcp-config.git" }
 mcp-coder-utils = { git = "https://github.com/MarcusJellinghaus/mcp-coder-utils.git" }
 mcp-workspace = { git = "https://github.com/MarcusJellinghaus/mcp-workspace.git" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -149,13 +149,7 @@ where = ["src"]
 [tool.setuptools.package-data]
 "*" = ["py.typed"]
 
-[tool.uv]
-# Break the self-referential cycle: mcp-coder declares mcp-tools-py via git URL,
-# but this project IS mcp-tools-py. Strip the URL constraint so the local install wins.
-override-dependencies = ["mcp-tools-py"]
-
 [tool.uv.sources]
-mcp-tools-py = { path = ".", editable = true }
 mcp-config-tool = { git = "https://github.com/MarcusJellinghaus/mcp-config.git" }
 mcp-coder-utils = { git = "https://github.com/MarcusJellinghaus/mcp-coder-utils.git" }
 mcp-workspace = { git = "https://github.com/MarcusJellinghaus/mcp-workspace.git" }


### PR DESCRIPTION
## Summary
- Sibling dependencies (e.g. `mcp-coder`) declare `mcp-tools-py` via git URL, which conflicts with the local project install during `uv sync`:
  ```
  error: Requirements contain conflicting URLs for package `mcp-tools-py`:
   - C:\...\mcp-tools-py
   - git+https://github.com/MarcusJellinghaus/mcp-tools-py.git
  ```
- Add a `[tool.uv.sources]` override pinning `mcp-tools-py` to the local editable path so the self-reference always resolves locally.

## Test plan
- [ ] `uv sync` completes without the conflicting-URLs error on a fresh checkout