### PR TITLE
chore(mcp): switch to MCP_CODER_VENV_PATH and enable alwaysLoad

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -2,7 +2,7 @@
   "mcpServers": {
     "mcp-tools-py": {
       "type": "stdio",
-      "command": "${VIRTUAL_ENV}\\Scripts\\mcp-tools-py.exe",
+      "command": "${MCP_CODER_VENV_PATH}\\mcp-tools-py.exe",
       "args": [
         "--project-dir",
         "${MCP_CODER_PROJECT_DIR}",
@@ -17,11 +17,12 @@
       ],
       "env": {
         "PYTHONPATH": "${MCP_CODER_PROJECT_DIR}/src"
-      }
+      },
+      "alwaysLoad": true
     },
     "mcp-workspace": {
       "type": "stdio",
-      "command": "${VIRTUAL_ENV}\\Scripts\\mcp-workspace.exe",
+      "command": "${MCP_CODER_VENV_PATH}\\mcp-workspace.exe",
       "args": [
         "--project-dir",
         "${MCP_CODER_PROJECT_DIR}",
@@ -38,7 +39,8 @@
       ],
       "env": {
         "PYTHONPATH": "${MCP_CODER_VENV_DIR}\\Lib\\"
-      }
+      },
+      "alwaysLoad": true
     }
   }
 }

--- a/.mcp.macos.json
+++ b/.mcp.macos.json
@@ -2,7 +2,7 @@
   "mcpServers": {
     "mcp-tools-py": {
       "type": "stdio",
-      "command": "${VIRTUAL_ENV}/bin/mcp-tools-py",
+      "command": "${MCP_CODER_VENV_PATH}/mcp-tools-py",
       "args": [
         "--project-dir",
         "${MCP_CODER_PROJECT_DIR}",
@@ -17,11 +17,12 @@
       ],
       "env": {
         "PYTHONPATH": "${MCP_CODER_PROJECT_DIR}/src"
-      }
+      },
+      "alwaysLoad": true
     },
     "mcp-workspace": {
       "type": "stdio",
-      "command": "${VIRTUAL_ENV}/bin/mcp-workspace",
+      "command": "${MCP_CODER_VENV_PATH}/mcp-workspace",
       "args": [
         "--project-dir",
         "${MCP_CODER_PROJECT_DIR}",
@@ -38,7 +39,8 @@
       ],
       "env": {
         "PYTHONPATH": "${MCP_CODER_VENV_DIR}/lib"
-      }
+      },
+      "alwaysLoad": true
     }
   }
 }

--- a/claude.sh
+++ b/claude.sh
@@ -74,6 +74,8 @@ export MCP_CODER_VENV_PATH
 export MCP_CODER_VENV_DIR
 export MCP_CODER_PROJECT_DIR="$PWD"
 export DISABLE_AUTOUPDATER=1
+# See src/mcp_coder/llm/claude_settings.py for canonical value
+export MCP_TIMEOUT=30000
 export PATH="$MCP_CODER_VENV_PATH:$PATH"
 
 # === Step 6: Platform-specific MCP config override ===


### PR DESCRIPTION
## Summary
- Replace `${VIRTUAL_ENV}` with `${MCP_CODER_VENV_PATH}` in `.mcp.json` and `.mcp.macos.json`
- Add `alwaysLoad: true` to both `mcp-tools-py` and `mcp-workspace` server entries
- Set `MCP_TIMEOUT=30000` in `claude.sh`