### PR TITLE
chore(mcp): add obsidian-dev-wiki reference project

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -35,7 +35,9 @@
         "--reference-project",
         "name=mcp-workspace,path=${USERPROFILE}\\Documents\\GitHub\\mcp-workspace,url=https://github.com/MarcusJellinghaus/mcp-workspace",
         "--reference-project",
-        "name=mcp-coder-utils,path=${USERPROFILE}\\Documents\\GitHub\\mcp-coder-utils,url=https://github.com/MarcusJellinghaus/mcp-coder-utils"
+        "name=mcp-coder-utils,path=${USERPROFILE}\\Documents\\GitHub\\mcp-coder-utils,url=https://github.com/MarcusJellinghaus/mcp-coder-utils",
+        "--reference-project",
+        "name=obsidian-dev-wiki,path=${USERPROFILE}\\Documents\\GitHub\\obsidian-dev-wiki,url=https://github.com/MarcusJellinghaus/obsidian-dev-wiki"
       ],
       "env": {
         "PYTHONPATH": "${MCP_CODER_VENV_DIR}\\Lib\\"

--- a/.mcp.macos.json
+++ b/.mcp.macos.json
@@ -35,7 +35,9 @@
         "--reference-project",
         "name=mcp-workspace,path=${HOME}/Documents/GitHub/mcp-workspace,url=https://github.com/MarcusJellinghaus/mcp-workspace",
         "--reference-project",
-        "name=mcp-coder-utils,path=${HOME}/Documents/GitHub/mcp-coder-utils,url=https://github.com/MarcusJellinghaus/mcp-coder-utils"
+        "name=mcp-coder-utils,path=${HOME}/Documents/GitHub/mcp-coder-utils,url=https://github.com/MarcusJellinghaus/mcp-coder-utils",
+        "--reference-project",
+        "name=obsidian-dev-wiki,path=${HOME}/Documents/GitHub/obsidian-dev-wiki,url=https://github.com/MarcusJellinghaus/obsidian-dev-wiki"
       ],
       "env": {
         "PYTHONPATH": "${MCP_CODER_VENV_DIR}/lib"


### PR DESCRIPTION
## Summary
- Add `obsidian-dev-wiki` as a reference project in `.mcp.json` (Windows) and `.mcp.macos.json` (macOS)
- Path: `~/Documents/GitHub/obsidian-dev-wiki`