### PR TITLE
ci: break the mcp-coder URL cycle so the pipeline can install

### DIFF
--- a/.claude/Claude.md
+++ b/.claude/Claude.md
@@ -70,6 +70,8 @@ mcp__mcp-tools-py__run_mypy_check
 
 All checks must pass before proceeding.
 
+**Ruff:** use `mcp__mcp-tools-py__run_ruff_check`. Do not call `ruff` directly.
+
 **Pytest:** always use `extra_args: ["-n", "auto"]` for parallel execution.
 
 Available marker: `integration` (requires external resources).
@@ -119,6 +121,14 @@ mcp-coder check file-size --max-lines 750
 ## Writing style
 
 Be concise. If one line works, don't use three.
+
+## Obsidian knowledge base
+
+An Obsidian vault (`obsidian-dev-wiki`) is available as a reference project at `~/Documents/GitHub/obsidian-dev-wiki`.
+
+- **Read first:** At the start of non-trivial tasks, search the vault for relevant context — repo notes, processes, known issues, prior decisions.
+- **Follow processes:** When a task matches a documented process in `Processes/` (e.g. `Chore Implementation.md`), follow those steps.
+- **Write back:** Update the vault when you learn something worth preserving for future sessions.
 
 ## MCP server issues
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -142,14 +142,20 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - name: Install uv
-        uses: astral-sh/setup-uv@v7
+      - name: Set up Python 3.11
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
 
       - name: Check file sizes
-        # mcp-coder is run via uvx in an isolated environment.
-        # --with . ensures uvx uses THIS branch's mcp_tools_py instead of
-        # whatever version mcp_coder would resolve as a transitive dependency.
-        run: uvx --from "git+https://github.com/MarcusJellinghaus/mcp_coder.git" --with . mcp-coder check file-size --max-lines 750 --allowlist-file .large-files-allowlist
+        # Previously: `uvx --from git+mcp_coder --with . mcp-coder check file-size`.
+        # That invocation hits the irreducible URL cycle documented in #107
+        # Section 3 (mcp-coder source-pins mcp-tools-py via git, conflicting
+        # with the local `--with .` install). Inline the check instead — the
+        # behaviour matches mcp-coder's `check file-size` for our purposes:
+        # list git-tracked text files, count lines, fail on > max-lines unless
+        # allowlisted.
+        run: python tools/check_file_size.py --max-lines 750 --allowlist-file .large-files-allowlist
 
   # Architecture and code quality checks (PR only)
   architecture:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,6 +110,7 @@ jobs:
           - {name: "pylint", cmd: "pylint --version && pylint -E ./src ./tests"}
           - {name: "pytest", cmd: "pytest --version && pytest tests"}
           - {name: "mypy", cmd: "mypy --version && mypy --strict src tests"}
+          - {name: "ruff-docstrings", cmd: "ruff --version && ruff check src tests"}
     name: ${{ matrix.check.name }}
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/upstream-mypy-check.yml
+++ b/.github/workflows/upstream-mypy-check.yml
@@ -28,15 +28,11 @@ jobs:
         with:
           python-version: "3.11"
 
-      # Order matters: install upstream from git BEFORE `.[typecheck]`
-      # so uv's resolver doesn't replace it with a PyPI version. The base
-      # pyproject.toml has no version pin on mcp-coder-utils, so any
-      # already-installed version satisfies the constraint.
-      - name: Install mcp-coder-utils from main
-        run: uv pip install --system "mcp-coder-utils @ git+https://github.com/MarcusJellinghaus/mcp-coder-utils.git"
-
-      - name: Install mcp-tools-py with typecheck extra
-        run: uv pip install --system ".[typecheck]"
+      - name: Install dependencies
+        run: |
+          uv pip install --system \
+            "mcp-coder-utils @ git+https://github.com/MarcusJellinghaus/mcp-coder-utils.git" \
+            ".[typecheck]"
 
       - name: Run mypy --strict
         run: mypy --strict src tests

--- a/.large-files-allowlist
+++ b/.large-files-allowlist
@@ -10,6 +10,7 @@ tests/test_server_params.py
 
 # Core implementation files that may be legitimately large
 src/mcp_tools_py/checker_tools.py
+src/mcp_tools_py/refactoring/rope_tools.py
 src/mcp_tools_py/server.py
 src/mcp_tools_py/utils/data_files.py
 src/mcp_tools_py/utils/subprocess_runner.py

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,6 @@ dependencies = [
 [project.optional-dependencies]
 dev = [
     "mcp-workspace",
-    "mcp-coder",
     # Architecture and code quality tools
     "tach>=0.15.0",
     "pycycle>=0.0.8",
@@ -174,7 +173,6 @@ where = ["src"]
 mcp-config-tool = { git = "https://github.com/MarcusJellinghaus/mcp-config.git" }
 mcp-coder-utils = { git = "https://github.com/MarcusJellinghaus/mcp-coder-utils.git" }
 mcp-workspace = { git = "https://github.com/MarcusJellinghaus/mcp-workspace.git" }
-mcp-coder = { git = "https://github.com/MarcusJellinghaus/mcp_coder.git" }
 
 [build-system]
 requires = ["setuptools>=61.0", "setuptools-scm>=8.0"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,6 +80,27 @@ profile = "black"
 line_length = 88
 float_to_top = true
 
+[tool.ruff]
+target-version = "py311"
+line-length = 88
+
+[tool.ruff.lint]
+# Only enable docstring rules for now
+# preview needed for DOC rules (pydoclint)
+preview = true
+select = ["D", "DOC"]
+ignore = [
+    "D104",  # missing docstring in __init__.py (low value)
+    "D107",  # missing docstring in __init__ method (redundant with class docstring)
+]
+
+[tool.ruff.lint.per-file-ignores]
+"tests/**/*.py" = ["D", "DOC"]
+"src/mcp_tools_py/code_checker_ruff/*.py" = ["DOC502"]
+
+[tool.ruff.lint.pydocstyle]
+convention = "google"
+
 [tool.mypy]
 python_version = "3.11"
 warn_return_any = true

--- a/src/mcp_tools_py/checker_tools.py
+++ b/src/mcp_tools_py/checker_tools.py
@@ -62,13 +62,15 @@ class CheckerTools:
             target_directories: Optional[List[str]] = None,
             max_issues: int = 1,
         ) -> str:
-            """
-            Run pylint on the project code and generate smart prompts for LLMs.
+            """Run pylint on the project code and generate smart prompts for LLMs.
 
             Args:
                 extra_args: Additional pylint arguments.
                 target_directories: Directories to analyze relative to project_dir. Auto-detected from pyproject.toml when None.
                 max_issues: Number of issue types to show in detail (default: 1). Remaining issues shown as summary counts.
+
+            Returns:
+                Formatted pylint result, or an error message string.
             """
             if not self._server._is_tool_available("pylint"):
                 return (
@@ -136,8 +138,7 @@ class CheckerTools:
             extra_args: Optional[List[str]] = None,
             env_vars: Optional[Dict[str, str]] = None,
         ) -> str:
-            """
-            Run pytest on the project code and generate smart prompts for LLMs.
+            """Run pytest on the project code and generate smart prompts for LLMs.
 
             Args:
                 markers: Optional list of pytest markers to filter tests. Examples: ['slow', 'integration']
@@ -278,8 +279,7 @@ class CheckerTools:
             follow_imports: str | None = None,
             cache_dir: str | None = None,
         ) -> str:
-            """
-            Run mypy type checking on the project code.
+            """Run mypy type checking on the project code.
 
             Args:
                 strict: Use strict mode settings (default: True).
@@ -293,12 +293,9 @@ class CheckerTools:
                     - 'attr-defined': Attribute not defined errors
                     - 'var-annotated': Missing variable annotations
                 target_directories: Optional list of directories to check relative to project_dir.
-                    Auto-detected from pyproject.toml when None.
-                    Examples:
-                    - ["src"] - Check only source code
-                    - ["src", "tests"] - Check both source and tests
-                    - ["mypackage"] - Check custom package
-                    - ["."] - Check entire project
+                    Auto-detected from pyproject.toml when None. For example:
+                    ["src"] (source only), ["src", "tests"] (both),
+                    ["mypackage"] (custom package), ["."] (entire project).
                 follow_imports: How to handle imports during type checking.
                     Options:
                     - 'normal' (default): Follow and type check imported modules
@@ -380,8 +377,7 @@ class CheckerTools:
         def run_lint_imports_check(
             extra_args: Optional[List[str]] = None,
         ) -> str:
-            """
-            Run lint-imports on the project to check import contracts.
+            """Run lint-imports on the project to check import contracts.
 
             Args:
                 extra_args: Additional lint-imports arguments.
@@ -434,8 +430,7 @@ class CheckerTools:
             min_confidence: int = 60,
             extra_args: Optional[List[str]] = None,
         ) -> str:
-            """
-            Run vulture on the project to find unused code.
+            """Run vulture on the project to find unused code.
 
             Args:
                 target_directories: Directories to scan relative to project_dir.
@@ -528,6 +523,9 @@ class CheckerTools:
                 target_directories: Directories to check relative to project_dir. Auto-detected when None.
                 extra_args: Additional ruff CLI flags (e.g. ["--preview"] for DOC rules).
                 max_issues: Number of issue types shown in detail (default: 1).
+
+            Returns:
+                Formatted ruff report, or an error message string.
             """
             if not self._server._is_tool_available("ruff"):
                 binary_path = self._server._ruff_binary or "N/A"
@@ -607,6 +605,9 @@ class CheckerTools:
                 select: Override rule selection. Defaults to project config.
                 target_directories: Directories to fix relative to project_dir. Auto-detected when None.
                 extra_args: Additional ruff CLI flags.
+
+            Returns:
+                Formatted fix report, or an error message string.
             """
             if not self._server._is_tool_available("ruff"):
                 binary_path = self._server._ruff_binary or "N/A"
@@ -683,6 +684,9 @@ class CheckerTools:
                 extra_args: Additional bandit CLI flags.
                 max_issues: Number of issue types to show in detail (default: 1).
                     Remaining issues shown as summary counts.
+
+            Returns:
+                Formatted bandit report, or an error message string.
             """
             if not self._server._is_tool_available("bandit"):
                 binary_path = self._server._bandit_binary or "N/A"
@@ -794,7 +798,11 @@ class CheckerTools:
                 return error_msg
 
     def _format_pylint_result(self, pylint_prompt: Optional[str]) -> str:
-        """Format pylint check result."""
+        """Format pylint check result.
+
+        Returns:
+            User-facing summary of the pylint outcome.
+        """
         if pylint_prompt is None:
             return "Pylint check completed. No issues found that require attention."
         return pylint_prompt
@@ -802,7 +810,11 @@ class CheckerTools:
     def _format_pytest_result_with_details(
         self, test_results: dict[str, Any], show_details: bool
     ) -> str:
-        """Enhanced formatting that respects show_details parameter."""
+        """Enhanced formatting that respects show_details parameter.
+
+        Returns:
+            User-facing summary of the pytest outcome.
+        """
         if not test_results["success"]:
             return f"Error running pytest: {test_results.get('error', 'Unknown error')}"
 
@@ -855,7 +867,11 @@ class CheckerTools:
                 return f"Pytest check completed. All {passed_count} tests passed successfully."
 
     def _format_mypy_result(self, mypy_prompt: str | None) -> str:
-        """Format mypy check result."""
+        """Format mypy check result.
+
+        Returns:
+            User-facing summary of the mypy outcome.
+        """
         if mypy_prompt is None:
             return "Mypy check completed. No type errors found."
         return f"Mypy found type issues that need attention:\n\n{mypy_prompt}"

--- a/src/mcp_tools_py/code_checker_bandit/__init__.py
+++ b/src/mcp_tools_py/code_checker_bandit/__init__.py
@@ -1,6 +1,4 @@
-"""
-Code checker package that runs bandit security analysis and generates reports for LLMs.
-"""
+"""Code checker package that runs bandit security analysis and generates reports for LLMs."""
 
 from mcp_tools_py.code_checker_bandit.models import BanditMessage, BanditResult
 from mcp_tools_py.code_checker_bandit.parsers import parse_bandit_json_output

--- a/src/mcp_tools_py/code_checker_bandit/parsers.py
+++ b/src/mcp_tools_py/code_checker_bandit/parsers.py
@@ -1,6 +1,4 @@
-"""
-Functions for parsing bandit JSON output.
-"""
+"""Functions for parsing bandit JSON output."""
 
 import json
 import logging

--- a/src/mcp_tools_py/code_checker_bandit/reporting.py
+++ b/src/mcp_tools_py/code_checker_bandit/reporting.py
@@ -1,5 +1,4 @@
-"""
-Reporting layer for bandit security analysis results.
+"""Reporting layer for bandit security analysis results.
 
 Groups findings by test_id, sorts by severity/confidence/frequency,
 and formats LLM-optimized output with max_issues detail/summary control.
@@ -27,7 +26,11 @@ class BanditIssueGroup(NamedTuple):
 def group_and_sort_issues(
     messages: list[BanditMessage],
 ) -> list[BanditIssueGroup]:
-    """Group by test_id, sort by (severity, confidence, -frequency)."""
+    """Group by test_id, sort by (severity, confidence, -frequency).
+
+    Returns:
+        Issue groups sorted highest severity / confidence / count first.
+    """
     groups: dict[str, list[BanditMessage]] = defaultdict(list)
     for msg in messages:
         groups[msg.test_id].append(msg)
@@ -52,7 +55,11 @@ def format_bandit_report(
     errors: list[str],
     max_issues: int = 1,
 ) -> str | None:
-    """Format bandit results into LLM-optimized report. Returns None if no issues and no errors."""
+    """Format bandit results into an LLM-optimized report.
+
+    Returns:
+        Formatted report string, or None if there are no issues and no errors.
+    """
     sections: list[str] = []
 
     if errors:

--- a/src/mcp_tools_py/code_checker_bandit/runners.py
+++ b/src/mcp_tools_py/code_checker_bandit/runners.py
@@ -16,7 +16,11 @@ def _build_bandit_command(
     target_directories: list[str],
     extra_args: list[str] | None = None,
 ) -> list[str]:
-    """Build the bandit CLI command list."""
+    """Build the bandit CLI command list.
+
+    Returns:
+        Command argv ready to pass to `execute_command`.
+    """
     cmd = [bandit_binary, "-f", "json", "-r"]
     cmd.extend(target_directories)
     if extra_args:

--- a/src/mcp_tools_py/code_checker_lint_imports/runners.py
+++ b/src/mcp_tools_py/code_checker_lint_imports/runners.py
@@ -60,6 +60,9 @@ def _join_wrapped_warning_lines(combined: str) -> str:
     Walk lines in order; whenever a line starts with the warning prefix
     and does not yet end with '.', glue it to subsequent non-blank lines
     until a '.' terminator is reached or no further continuation exists.
+
+    Returns:
+        The input text with wrapped warning lines re-joined.
     """
     lines = combined.splitlines()
     out: list[str] = []
@@ -128,7 +131,11 @@ def _format_report(
     raw_body: str,
     info_line: str | None,
 ) -> str:
-    """Assemble the final string and apply the line cap."""
+    """Assemble the final string and apply the line cap.
+
+    Returns:
+        Multi-line report text, truncated to `MAX_OUTPUT_LINES`.
+    """
     lines: list[str] = []
 
     if info_line:
@@ -172,6 +179,9 @@ def run_lint_imports_check_impl(
 
     The first non-empty line is always either an info line (when flags
     were stripped) or the state header. Truncation cannot hide it.
+
+    Returns:
+        Structured report (state header + summary + raw output, capped).
     """
     cleaned_args, stripped = _strip_verbose_flags(extra_args)
     info_line = "[Info: stripped --verbose/-v from extra_args]" if stripped else None

--- a/src/mcp_tools_py/code_checker_mypy/models.py
+++ b/src/mcp_tools_py/code_checker_mypy/models.py
@@ -38,5 +38,9 @@ class MypyResult(NamedTuple):
         return {msg.code for msg in self.messages if msg.code}
 
     def get_messages_by_severity(self, severity: str) -> list[MypyMessage]:
-        """Filter messages by severity level."""
+        """Filter messages by severity level.
+
+        Returns:
+            Messages whose `severity` matches the requested level.
+        """
         return [msg for msg in self.messages if msg.severity == severity]

--- a/src/mcp_tools_py/code_checker_mypy/parsers.py
+++ b/src/mcp_tools_py/code_checker_mypy/parsers.py
@@ -9,8 +9,7 @@ logger = logging.getLogger(__name__)
 
 
 def parse_mypy_json_output(output: str) -> tuple[list[MypyMessage], str | None]:
-    """
-    Parse mypy JSON output into MypyMessage objects.
+    """Parse mypy JSON output into MypyMessage objects.
 
     Mypy outputs one JSON object per line when using --output json.
 

--- a/src/mcp_tools_py/code_checker_mypy/reporting.py
+++ b/src/mcp_tools_py/code_checker_mypy/reporting.py
@@ -8,8 +8,7 @@ logger = logging.getLogger(__name__)
 
 
 def create_mypy_prompt(result: MypyResult) -> str | None:
-    """
-    Generate LLM-friendly prompt from mypy results.
+    """Generate LLM-friendly prompt from mypy results.
 
     Args:
         result: MypyResult from type checking

--- a/src/mcp_tools_py/code_checker_mypy/runners.py
+++ b/src/mcp_tools_py/code_checker_mypy/runners.py
@@ -43,8 +43,7 @@ def run_mypy_check(
     cache_dir: str | None = None,
     config_file: str | None = None,
 ) -> MypyResult:
-    """
-    Run mypy type checking on project.
+    """Run mypy type checking on project.
 
     Args:
         project_dir: Path to the project directory
@@ -58,6 +57,9 @@ def run_mypy_check(
 
     Returns:
         MypyResult with execution results
+
+    Raises:
+        FileNotFoundError: If `project_dir` does not exist.
     """
     if not os.path.isdir(project_dir):
         raise FileNotFoundError(f"Project directory not found: {project_dir}")

--- a/src/mcp_tools_py/code_checker_pylint/__init__.py
+++ b/src/mcp_tools_py/code_checker_pylint/__init__.py
@@ -1,5 +1,4 @@
-"""
-Code checker package that runs pylint analysis and generates smart prompts for LLMs.
+"""Code checker package that runs pylint analysis and generates smart prompts for LLMs.
 
 This package provides functionality to run pylint on a given project
 and process the analysis results.

--- a/src/mcp_tools_py/code_checker_pylint/models.py
+++ b/src/mcp_tools_py/code_checker_pylint/models.py
@@ -1,6 +1,4 @@
-"""
-Data models for pylint analysis results.
-"""
+"""Data models for pylint analysis results."""
 
 from enum import Enum
 from typing import List, NamedTuple, Optional, Set

--- a/src/mcp_tools_py/code_checker_pylint/parsers.py
+++ b/src/mcp_tools_py/code_checker_pylint/parsers.py
@@ -1,6 +1,4 @@
-"""
-Functions for parsing pylint output.
-"""
+"""Functions for parsing pylint output."""
 
 import json
 import logging
@@ -14,8 +12,7 @@ logger = logging.getLogger(__name__)
 def parse_pylint_json_output(
     raw_output: str,
 ) -> tuple[List[PylintMessage], str | None]:
-    """
-    Parse pylint JSON output into PylintMessage objects.
+    """Parse pylint JSON output into PylintMessage objects.
 
     Args:
         raw_output: Raw JSON output from pylint

--- a/src/mcp_tools_py/code_checker_pylint/reporting.py
+++ b/src/mcp_tools_py/code_checker_pylint/reporting.py
@@ -1,6 +1,4 @@
-"""
-Functions for generating reports and prompts from pylint analysis results.
-"""
+"""Functions for generating reports and prompts from pylint analysis results."""
 
 import json
 import logging
@@ -37,7 +35,11 @@ class IssueGroup(NamedTuple):
 
 
 def _group_and_sort_issues(messages: list[PylintMessage]) -> list[IssueGroup]:
-    """Group messages by message_id, sort by severity then frequency (descending)."""
+    """Group messages by message_id, sort by severity then frequency (descending).
+
+    Returns:
+        Issue groups sorted highest severity / most-frequent first.
+    """
     groups: dict[str, list[PylintMessage]] = defaultdict(list)
     for msg in messages:
         groups[msg.message_id].append(msg)
@@ -62,8 +64,7 @@ logger = logging.getLogger(__name__)
 
 
 def get_direct_instruction_for_pylint_code(code: str) -> Optional[str]:
-    """
-    Provides a direct instruction for a given Pylint code.
+    """Provides a direct instruction for a given Pylint code.
 
     Args:
         code: The Pylint code (e.g., "R0902", "C0411", "W0612").
@@ -103,8 +104,7 @@ def get_direct_instruction_for_pylint_code(code: str) -> Optional[str]:
 def get_prompt_for_known_pylint_code(
     code: str, project_dir: str, pylint_results: PylintResult
 ) -> Optional[str]:
-    """
-    Generate a prompt for a known pylint code with instructions and details.
+    """Generate a prompt for a known pylint code with instructions and details.
 
     Args:
         code: The pylint code (e.g., "E0602")
@@ -146,8 +146,7 @@ def get_prompt_for_known_pylint_code(
 def get_prompt_for_unknown_pylint_code(
     code: str, project_dir: str, pylint_results: PylintResult
 ) -> str:
-    """
-    Generate a prompt for an unknown pylint code with issue details.
+    """Generate a prompt for an unknown pylint code with issue details.
 
     Args:
         code: The pylint code (e.g., "E0602")
@@ -199,8 +198,7 @@ def get_pylint_prompt(
     target_directories: list[str] | None = None,
     max_issues: int = 1,
 ) -> Optional[str]:
-    """
-    Generate a prompt for fixing pylint issues based on the analysis of a project.
+    """Generate a prompt for fixing pylint issues based on the analysis of a project.
 
     Args:
         project_dir: The path to the project directory to analyze.

--- a/src/mcp_tools_py/code_checker_pylint/runners.py
+++ b/src/mcp_tools_py/code_checker_pylint/runners.py
@@ -1,6 +1,4 @@
-"""
-Functions for running pylint analysis and processing results.
-"""
+"""Functions for running pylint analysis and processing results."""
 
 import logging
 import os
@@ -25,8 +23,7 @@ def get_pylint_results(
     extra_args: List[str] | None = None,
     target_directories: List[str] | None = None,
 ) -> PylintResult:
-    """
-    Runs pylint on the specified project directory and returns the results.
+    """Runs pylint on the specified project directory and returns the results.
 
     Args:
         project_dir: The path to the project directory.

--- a/src/mcp_tools_py/code_checker_pylint/utils.py
+++ b/src/mcp_tools_py/code_checker_pylint/utils.py
@@ -1,13 +1,10 @@
-"""
-Utility functions for pylint code checking.
-"""
+"""Utility functions for pylint code checking."""
 
 import os
 
 
 def normalize_path(path: str, base_dir: str) -> str:
-    """
-    Normalize a path relative to the base directory.
+    """Normalize a path relative to the base directory.
 
     Args:
         path: The path to normalize

--- a/src/mcp_tools_py/code_checker_pytest/__init__.py
+++ b/src/mcp_tools_py/code_checker_pytest/__init__.py
@@ -1,5 +1,4 @@
-"""
-Code checker package that runs pytest tests and analyzes the results.
+"""Code checker package that runs pytest tests and analyzes the results.
 
 This package provides functionality to run pytest tests on a given project
 and process the test results.

--- a/src/mcp_tools_py/code_checker_pytest/models.py
+++ b/src/mcp_tools_py/code_checker_pytest/models.py
@@ -1,6 +1,4 @@
-"""
-Data models for pytest test results and reports.
-"""
+"""Data models for pytest test results and reports."""
 
 from dataclasses import dataclass, field
 from typing import Any, Dict, List, Optional
@@ -8,6 +6,8 @@ from typing import Any, Dict, List, Optional
 
 @dataclass
 class Crash:
+    """Crash details from a pytest failure."""
+
     path: str
     lineno: int
     message: str
@@ -15,6 +15,8 @@ class Crash:
 
 @dataclass
 class TracebackEntry:
+    """Single traceback frame from a pytest failure."""
+
     path: str
     lineno: int
     message: str
@@ -59,11 +61,15 @@ class LogRecord:
 
 @dataclass
 class Log:
+    """Container for a list of log records."""
+
     logs: List[LogRecord]
 
 
 @dataclass
 class StageInfo:
+    """Per-stage info (setup/call/teardown) for a single test."""
+
     duration: float
     outcome: str
     crash: Optional[Crash] = None
@@ -76,6 +82,8 @@ class StageInfo:
 
 @dataclass
 class Test:
+    """Single pytest test result with per-stage info."""
+
     nodeid: str
     lineno: int
     keywords: List[str]
@@ -88,6 +96,8 @@ class Test:
 
 @dataclass
 class CollectorResult:
+    """One item discovered by a pytest collector."""
+
     nodeid: str
     type: str
     lineno: Optional[int] = None
@@ -96,6 +106,8 @@ class CollectorResult:
 
 @dataclass
 class Collector:
+    """A pytest collector and its discovered items."""
+
     nodeid: str
     outcome: str
     result: List[CollectorResult]
@@ -104,6 +116,8 @@ class Collector:
 
 @dataclass
 class Summary:
+    """Aggregate test counts from a pytest run."""
+
     collected: int
     total: int
     deselected: Optional[int] = None
@@ -117,6 +131,8 @@ class Summary:
 
 @dataclass
 class Warning:
+    """A pytest warning emitted during a run."""
+
     message: str
     code: Optional[str] = None
     path: Optional[str] = None
@@ -129,6 +145,8 @@ class Warning:
 
 @dataclass
 class ErrorContext:
+    """Decoded error context for a non-zero pytest exit."""
+
     exit_code: int
     exit_code_meaning: str
     error_message: str
@@ -139,6 +157,8 @@ class ErrorContext:
 
 @dataclass
 class PytestReport:
+    """Top-level pytest-json-report payload parsed into typed fields."""
+
     created: float
     duration: float
     exitcode: int

--- a/src/mcp_tools_py/code_checker_pytest/parsers.py
+++ b/src/mcp_tools_py/code_checker_pytest/parsers.py
@@ -1,6 +1,4 @@
-"""
-Functions for parsing pytest test results and output.
-"""
+"""Functions for parsing pytest test results and output."""
 
 import json
 from dataclasses import fields
@@ -26,8 +24,7 @@ LOG_RECORD_FIELDS = {f.name for f in fields(LogRecord)} - {"extra"}
 
 
 def parse_test_stage(stage_data: Dict[str, Any]) -> StageInfo:
-    """
-    Parse test stage data from the pytest JSON report.
+    """Parse test stage data from the pytest JSON report.
 
     Args:
         stage_data: Dictionary containing test stage data from JSON
@@ -69,8 +66,7 @@ def parse_test_stage(stage_data: Dict[str, Any]) -> StageInfo:
 
 
 def parse_pytest_report(json_data: str) -> PytestReport:
-    """
-    Parse a JSON string into a PytestReport object.
+    """Parse a JSON string into a PytestReport object.
 
     Args:
         json_data: JSON string from pytest json report

--- a/src/mcp_tools_py/code_checker_pytest/reporting.py
+++ b/src/mcp_tools_py/code_checker_pytest/reporting.py
@@ -1,6 +1,4 @@
-"""
-Functions for formatting and reporting pytest test results.
-"""
+"""Functions for formatting and reporting pytest test results."""
 
 import logging
 from typing import Any, Dict, List, Optional, Tuple
@@ -17,9 +15,7 @@ FAILED_OUTCOMES = ["failed", "error"]
 
 
 class OutputBuilder:
-    """
-    Helper class to manage output building with line counting and truncation.
-    """
+    """Helper class to manage output building with line counting and truncation."""
 
     def __init__(self, max_lines: int = MAX_OUTPUT_LINES):
         self.parts: List[str] = []
@@ -28,8 +24,7 @@ class OutputBuilder:
         self.truncated = False
 
     def add(self, content: str) -> bool:
-        """
-        Add content to the output, checking line limits.
+        """Add content to the output, checking line limits.
 
         Args:
             content: Content to add
@@ -57,13 +52,16 @@ class OutputBuilder:
         return True
 
     def get_result(self) -> str:
-        """Get the final output string."""
+        """Get the final output string.
+
+        Returns:
+            All appended parts concatenated.
+        """
         return "".join(self.parts)
 
 
 def should_show_details(_test_results: Dict[str, Any], show_details: bool) -> bool:
-    """
-    Determine if detailed output should be shown based on test results and user preference.
+    """Determine if detailed output should be shown based on test results and user preference.
 
     Args:
         _test_results: Dictionary containing test summary information (currently unused)
@@ -82,7 +80,11 @@ def should_show_details(_test_results: Dict[str, Any], show_details: bool) -> bo
 
 
 def _get_failed_collectors(test_session_result: PytestReport) -> List[Collector]:
-    """Extract failed collectors from test session result."""
+    """Extract failed collectors from test session result.
+
+    Returns:
+        Collectors whose outcome is failed or error.
+    """
     if not test_session_result.collectors:
         return []
 
@@ -96,7 +98,11 @@ def _get_failed_collectors(test_session_result: PytestReport) -> List[Collector]
 def _get_failed_tests(
     test_session_result: PytestReport, max_failures: int
 ) -> List[Test]:
-    """Extract and limit failed tests from test session result."""
+    """Extract and limit failed tests from test session result.
+
+    Returns:
+        Up to `max_failures` failed/errored tests.
+    """
     if not test_session_result.tests:
         return []
 
@@ -108,8 +114,7 @@ def _get_failed_tests(
 
 
 def _format_collector_info(collector: Collector, output: OutputBuilder) -> bool:
-    """
-    Format information about a failed collector.
+    """Format information about a failed collector.
 
     Args:
         collector: The failed collector to format
@@ -139,8 +144,7 @@ def _format_collector_info(collector: Collector, output: OutputBuilder) -> bool:
 def _format_test_output(
     test: Test, output: OutputBuilder, include_print_output: bool
 ) -> bool:
-    """
-    Format stdout, stderr, and longrepr output for a test.
+    """Format stdout, stderr, and longrepr output for a test.
 
     Args:
         test: The test to format output for
@@ -171,8 +175,7 @@ def _format_test_output(
 def _format_test_setup_info(
     test: Test, output: OutputBuilder, include_print_output: bool
 ) -> bool:
-    """
-    Format setup information for a failed test.
+    """Format setup information for a failed test.
 
     Args:
         test: The test with failed setup
@@ -225,8 +228,7 @@ def _format_test_setup_info(
 def _format_test_info(
     test: Test, output: OutputBuilder, include_print_output: bool
 ) -> bool:
-    """
-    Format information about a failed test.
+    """Format information about a failed test.
 
     Args:
         test: The failed test to format
@@ -266,8 +268,7 @@ def _format_test_info(
 def _process_failed_collectors(
     failed_collectors: List[Collector], output: OutputBuilder
 ) -> bool:
-    """
-    Process and format all failed collectors.
+    """Process and format all failed collectors.
 
     Args:
         failed_collectors: List of failed collectors
@@ -295,8 +296,7 @@ def _process_failed_tests(
     include_print_output: bool,
     max_number_of_tests_reported: int,
 ) -> bool:
-    """
-    Process and format failed tests.
+    """Process and format failed tests.
 
     Args:
         failed_tests: List of failed tests
@@ -343,8 +343,7 @@ def create_prompt_for_failed_tests(
     max_failures: int = MAX_FAILURES,
     max_output_lines: int = MAX_OUTPUT_LINES,
 ) -> Optional[str]:
-    """
-    Creates a prompt for an LLM based on the failed tests from a test session result.
+    """Creates a prompt for an LLM based on the failed tests from a test session result.
 
     Args:
         test_session_result: The test session result to analyze
@@ -385,8 +384,7 @@ def create_prompt_for_failed_tests(
 def get_detailed_test_summary(
     test_session_result: PytestReport, show_details: bool
 ) -> str:
-    """
-    Enhanced summary that can include additional detail hints.
+    """Enhanced summary that can include additional detail hints.
 
     Args:
         test_session_result: The test session result to summarize
@@ -412,8 +410,7 @@ def get_detailed_test_summary(
 
 
 def get_test_summary(test_session_result: PytestReport) -> str:
-    """
-    Generate a human-readable summary of the test results.
+    """Generate a human-readable summary of the test results.
 
     Args:
         test_session_result: The test session result to summarize

--- a/src/mcp_tools_py/code_checker_pytest/runners.py
+++ b/src/mcp_tools_py/code_checker_pytest/runners.py
@@ -1,6 +1,4 @@
-"""
-Functions for running pytest tests and processing results.
-"""
+"""Functions for running pytest tests and processing results."""
 
 import logging
 import os
@@ -24,7 +22,11 @@ from mcp_tools_py.utils.subprocess_runner import (
 
 
 def _build_error_detail(output: str, error_output: str) -> str:
-    """Build a stderr/stdout snippet string for error messages."""
+    """Build a stderr/stdout snippet string for error messages.
+
+    Returns:
+        Combined snippet with stderr/stdout sections, possibly empty.
+    """
     stderr_snippet = (
         truncate_stderr(error_output.strip())
         if error_output and error_output.strip()
@@ -45,8 +47,7 @@ logger = logging.getLogger(__name__)
 
 
 class ProcessResult:
-    """
-    Adapter class that mimics subprocess.CompletedProcess interface.
+    """Adapter class that mimics subprocess.CompletedProcess interface.
 
     This class serves as a bridge between our custom CommandResult from
     subprocess_runner and the standard subprocess.CompletedProcess interface
@@ -90,8 +91,7 @@ def run_tests(
     timeout_seconds: int = 300,
     skip_default_test_folder: bool = False,
 ) -> PytestReport:
-    """
-    Run pytest tests in the specified project directory and test folder and returns the results.
+    """Run pytest tests in the specified project directory and test folder and returns the results.
 
     Args:
         project_dir: The path to the project directory
@@ -104,7 +104,7 @@ def run_tests(
         venv_path: Optional path to a virtual environment to activate. When provided, this venv's Python will be used
         keep_temp_files: Whether to keep temporary files after execution (useful for debugging failures)
         timeout_seconds: Maximum time in seconds to wait for test execution. Default is 300 seconds
-
+        skip_default_test_folder: When True, do not append `test_folder` to the pytest command (caller already passed test paths via `extra_args`)
 
     Returns:
         PytestReport: An object containing the results of the test session with the following attributes:
@@ -113,9 +113,11 @@ def run_tests(
         - error_context: Information about any errors that occurred during execution
 
     Raises:
-        Exception: If pytest is not installed or if an error occurs during test execution
+        RuntimeError: For pytest internal errors, plugin errors, missing pytest, or
+            failure to install pytest-json-report.
+        TimeoutError: If pytest execution exceeds `timeout_seconds`.
+        ValueError: For pytest usage errors or when no tests are collected.
     """
-
     # Create a temporary directory for output files
     temp_dir = tempfile.mkdtemp(prefix="pytest_runner_")
     temp_report_file = os.path.join(temp_dir, "pytest_result.json")
@@ -471,8 +473,7 @@ def check_code_with_pytest(
     timeout_seconds: int = 300,
     skip_default_test_folder: bool = False,
 ) -> Dict[str, Any]:
-    """
-    Run pytest on the specified project and return results.
+    """Run pytest on the specified project and return results.
 
     Args:
         project_dir: Path to the project directory
@@ -485,7 +486,7 @@ def check_code_with_pytest(
         venv_path: Optional path to a virtual environment to activate for running tests. When specified, the Python executable from this venv will be used instead of python_executable
         keep_temp_files: Whether to keep temporary files after test execution. Useful for debugging when tests fail
         timeout_seconds: Maximum time in seconds to wait for test execution. Default is 300 seconds
-
+        skip_default_test_folder: When True, do not append `test_folder` to the pytest command (caller already passed test paths via `extra_args`)
 
     Returns:
         Dictionary with test results containing the following keys:

--- a/src/mcp_tools_py/code_checker_pytest/utils.py
+++ b/src/mcp_tools_py/code_checker_pytest/utils.py
@@ -1,6 +1,4 @@
-"""
-Utility functions for code checker pytest operations.
-"""
+"""Utility functions for code checker pytest operations."""
 
 import os
 from typing import List, Optional, Tuple
@@ -116,8 +114,7 @@ def sanitize_extra_args(
 
 
 def get_pytest_exit_code_info(exit_code: int) -> Tuple[str, str]:
-    """
-    Get detailed information and suggestions for pytest exit codes.
+    """Get detailed information and suggestions for pytest exit codes.
 
     Args:
         exit_code: The pytest exit code
@@ -178,8 +175,7 @@ def get_pytest_exit_code_info(exit_code: int) -> Tuple[str, str]:
 
 
 def create_error_context(exit_code: int, error_message: str) -> ErrorContext:
-    """
-    Create a detailed error context object with exit code interpretation.
+    """Create a detailed error context object with exit code interpretation.
 
     Args:
         exit_code: Pytest exit code

--- a/src/mcp_tools_py/code_checker_ruff/__init__.py
+++ b/src/mcp_tools_py/code_checker_ruff/__init__.py
@@ -1,6 +1,4 @@
-"""
-Code checker package that runs ruff analysis and generates smart prompts for LLMs.
-"""
+"""Code checker package that runs ruff analysis and generates smart prompts for LLMs."""
 
 from mcp_tools_py.code_checker_ruff.models import RuffMessage
 from mcp_tools_py.code_checker_ruff.parsers import parse_ruff_json_output

--- a/src/mcp_tools_py/code_checker_ruff/models.py
+++ b/src/mcp_tools_py/code_checker_ruff/models.py
@@ -1,6 +1,4 @@
-"""
-Data models for ruff analysis results.
-"""
+"""Data models for ruff analysis results."""
 
 from typing import NamedTuple
 

--- a/src/mcp_tools_py/code_checker_ruff/parsers.py
+++ b/src/mcp_tools_py/code_checker_ruff/parsers.py
@@ -1,6 +1,4 @@
-"""
-Functions for parsing ruff output.
-"""
+"""Functions for parsing ruff output."""
 
 import json
 import logging
@@ -16,8 +14,7 @@ def parse_ruff_json_output(
     raw_output: str,
     project_dir: str,
 ) -> tuple[List[RuffMessage], str | None]:
-    """
-    Parse ruff --output-format=json output into RuffMessage objects.
+    """Parse ruff --output-format=json output into RuffMessage objects.
 
     Args:
         raw_output: Raw JSON output from ruff

--- a/src/mcp_tools_py/code_checker_ruff/reporting.py
+++ b/src/mcp_tools_py/code_checker_ruff/reporting.py
@@ -1,5 +1,4 @@
-"""
-Reporting layer for ruff analysis results.
+"""Reporting layer for ruff analysis results.
 
 Groups violations by rule code, sorts by prefix category then frequency,
 and formats LLM-optimized output with max_issues detail/summary control.
@@ -30,7 +29,11 @@ class RuffIssueGroup(NamedTuple):
 
 
 def get_rule_prefix(code: str) -> str:
-    """Extract prefix from rule code: 'D100' -> 'D', 'DOC201' -> 'DOC'."""
+    """Extract prefix from rule code: 'D100' -> 'D', 'DOC201' -> 'DOC'.
+
+    Returns:
+        Leading alphabetic prefix of `code`.
+    """
     prefix = ""
     for char in code:
         if char.isalpha():
@@ -43,7 +46,11 @@ def get_rule_prefix(code: str) -> str:
 def group_and_sort_issues(
     messages: List[RuffMessage],
 ) -> List[RuffIssueGroup]:
-    """Group by code, sort by prefix priority then frequency (descending)."""
+    """Group by code, sort by prefix priority then frequency (descending).
+
+    Returns:
+        Issue groups sorted by rule-prefix priority and frequency.
+    """
     groups: dict[str, list[RuffMessage]] = defaultdict(list)
     for msg in messages:
         groups[msg.code].append(msg)
@@ -65,7 +72,11 @@ def format_ruff_check_report(
     messages: List[RuffMessage],
     max_issues: int = 1,
 ) -> Optional[str]:
-    """Format ruff check results into LLM prompt. Returns None if no issues."""
+    """Format ruff check results into an LLM prompt.
+
+    Returns:
+        Formatted report string, or None if there are no issues.
+    """
     groups = group_and_sort_issues(messages)
     if not groups:
         return None
@@ -110,7 +121,11 @@ def format_ruff_fix_report(
     changed_files: List[str],
     remaining_messages: List[RuffMessage],
 ) -> str:
-    """Format ruff fix results: changed files + remaining error summary."""
+    """Format ruff fix results: changed files + remaining error summary.
+
+    Returns:
+        Multi-line report listing fixes and any unfixed issues.
+    """
     lines: list[str] = [f"Ruff applied fixes to {len(changed_files)} files:"]
     for filepath in changed_files:
         lines.append(f"- {filepath}")

--- a/src/mcp_tools_py/code_checker_ruff/runners.py
+++ b/src/mcp_tools_py/code_checker_ruff/runners.py
@@ -22,7 +22,11 @@ def _build_ruff_command(
     output_format: str = "json",
     fix: bool = False,
 ) -> list[str]:
-    """Build the ruff CLI command list."""
+    """Build the ruff CLI command list.
+
+    Returns:
+        Command argv ready to pass to `execute_command`.
+    """
     cmd = [ruff_binary, "check"]
     if fix:
         cmd.append("--fix")
@@ -48,6 +52,9 @@ def run_ruff_check_impl(
 
     Returns:
         LLM-formatted report string, or "No issues found" message.
+
+    Raises:
+        FileNotFoundError: If `project_dir` does not exist.
     """
     if not os.path.isdir(project_dir):
         raise FileNotFoundError(f"Project directory not found: {project_dir}")
@@ -92,6 +99,9 @@ def run_ruff_fix_impl(
 
     Returns:
         Report with changed file list + remaining unfixed errors.
+
+    Raises:
+        FileNotFoundError: If `project_dir` does not exist.
     """
     if not os.path.isdir(project_dir):
         raise FileNotFoundError(f"Project directory not found: {project_dir}")

--- a/src/mcp_tools_py/formatter/black_runner.py
+++ b/src/mcp_tools_py/formatter/black_runner.py
@@ -10,7 +10,11 @@ _MAX_LINES = 200
 
 
 def _truncate_output(text: str) -> str:
-    """Truncate output to a maximum number of lines."""
+    """Truncate output to a maximum number of lines.
+
+    Returns:
+        Original text, or text capped at `_MAX_LINES` with a marker.
+    """
     lines = text.splitlines()
     if len(lines) <= _MAX_LINES:
         return text
@@ -26,6 +30,9 @@ def _parse_black_changed_files(output: str) -> list[str]:
     Black reports changed files as:
     - Normal mode: ``reformatted src/foo.py``
     - Check mode: ``would reformat src/foo.py``
+
+    Returns:
+        Paths of files black reformatted (or would reformat).
     """
     files: list[str] = []
     for line in output.splitlines():

--- a/src/mcp_tools_py/formatter/formatter_tools.py
+++ b/src/mcp_tools_py/formatter/formatter_tools.py
@@ -97,7 +97,11 @@ def _format_results(
     steps: list[str],
     check_only: bool,
 ) -> str:
-    """Format runner results into markdown output."""
+    """Format runner results into markdown output.
+
+    Returns:
+        Markdown report with one `## <step>` section per runner.
+    """
     sections: list[str] = []
     failed_step: str | None = None
 

--- a/src/mcp_tools_py/formatter/isort_runner.py
+++ b/src/mcp_tools_py/formatter/isort_runner.py
@@ -10,7 +10,11 @@ _MAX_LINES = 200
 
 
 def _truncate_output(text: str) -> str:
-    """Truncate output to a maximum number of lines."""
+    """Truncate output to a maximum number of lines.
+
+    Returns:
+        Original text, or text capped at `_MAX_LINES` with a marker.
+    """
     lines = text.splitlines()
     if len(lines) <= _MAX_LINES:
         return text
@@ -26,6 +30,9 @@ def _parse_isort_changed_files(output: str) -> list[str]:
     isort reports changed files as:
     - Normal mode: ``Fixing src/foo.py``
     - Check mode: ``ERROR: src/foo.py Imports are incorrectly sorted ...``
+
+    Returns:
+        Paths of files isort sorted (or would sort).
     """
     files: list[str] = []
     for line in output.splitlines():

--- a/src/mcp_tools_py/main.py
+++ b/src/mcp_tools_py/main.py
@@ -15,8 +15,7 @@ logger = logging.getLogger(__name__)
 
 
 def parse_args() -> argparse.Namespace:
-    """
-    Parse command line arguments.
+    """Parse command line arguments.
 
     Returns:
         Parsed arguments
@@ -113,9 +112,7 @@ Examples:
 
 
 def main() -> None:
-    """
-    Main entry point for the MCP server.
-    """
+    """Main entry point for the MCP server."""
     # Parse command line arguments
     args = parse_args()
 

--- a/src/mcp_tools_py/refactoring/__init__.py
+++ b/src/mcp_tools_py/refactoring/__init__.py
@@ -37,6 +37,9 @@ class RefactoringTools:
 
             Args:
                 file: File path relative to project root.
+
+            Returns:
+                Formatted listing of top-level symbols, or an error message.
             """
             return jedi_list_symbols(project_dir, file)
 
@@ -48,6 +51,9 @@ class RefactoringTools:
             Args:
                 file: File path relative to project root.
                 symbol_name: Name of the top-level symbol to find.
+
+            Returns:
+                Formatted listing of references, or an error message.
             """
             return jedi_find_references(project_dir, file, symbol_name)
 
@@ -70,6 +76,7 @@ class RefactoringTools:
             dry_run: bool = False,
         ) -> str:
             """Move top-level functions, classes, or variables to another module.
+
             Updates all imports project-wide. Auto-creates destination file and
             missing __init__.py files if needed.
 
@@ -78,6 +85,9 @@ class RefactoringTools:
                 symbol_names: Names of top-level symbols to move.
                 dest_file: Destination file path relative to project root.
                 dry_run: Preview changes without applying (default: False).
+
+            Returns:
+                Formatted summary of changes (or planned changes for dry-run).
             """
             return rope_move_symbol(
                 project_dir,
@@ -103,6 +113,9 @@ class RefactoringTools:
                 symbol_name: Current name of the symbol.
                 new_name: New name for the symbol.
                 dry_run: Preview changes without applying (default: False).
+
+            Returns:
+                Formatted summary of changes (or planned changes for dry-run).
             """
             return rope_rename_symbol(
                 project_dir,
@@ -126,6 +139,9 @@ class RefactoringTools:
                 source_module: Source module path relative to project root.
                 dest_package: Destination package path relative to project root.
                 dry_run: Preview changes without applying (default: False).
+
+            Returns:
+                Formatted summary of changes (or planned changes for dry-run).
             """
             return rope_move_module(
                 project_dir,

--- a/src/mcp_tools_py/refactoring/jedi_tools.py
+++ b/src/mcp_tools_py/refactoring/jedi_tools.py
@@ -46,7 +46,11 @@ def list_symbols(project_dir: Path, file_path: str) -> str:
 
 
 def _is_import(name: Any) -> bool:
-    """Check if a jedi Name originates from an import statement."""
+    """Check if a jedi Name originates from an import statement.
+
+    Returns:
+        True if the name is part of an `import` or `from ... import`.
+    """
     tree_name = getattr(getattr(name, "_name", None), "tree_name", None)
     if tree_name is None:
         return False
@@ -59,7 +63,11 @@ def _is_import(name: Any) -> bool:
 
 
 def _filter_top_level(names: List[Any], *, exclude_imports: bool = False) -> List[Any]:
-    """Filter jedi names to top-level symbols only."""
+    """Filter jedi names to top-level symbols only.
+
+    Returns:
+        Names whose parent scope is the module (optionally excluding imports).
+    """
     result: List[Any] = []
     for name in names:
         parent = name.parent()

--- a/src/mcp_tools_py/refactoring/rope_tools.py
+++ b/src/mcp_tools_py/refactoring/rope_tools.py
@@ -81,7 +81,11 @@ def read_gitignore_rules(
 
 
 def _build_ignored_resources(project_dir: Path) -> list[str]:
-    """Build rope ignored_resources from .gitignore + hardcoded defaults."""
+    """Build rope ignored_resources from .gitignore + hardcoded defaults.
+
+    Returns:
+        Patterns to pass as rope's `ignored_resources`.
+    """
     patterns = list(_DEFAULT_IGNORED)
 
     gitignore_path = project_dir / ".gitignore"
@@ -115,7 +119,11 @@ def _build_ignored_resources(project_dir: Path) -> list[str]:
 
 @contextmanager
 def _with_rope_project(project_dir: Path) -> Iterator[Project]:
-    """Context manager: open fresh rope Project, yield, close."""
+    """Context manager: open fresh rope Project, yield, close.
+
+    Yields:
+        A configured `rope.base.project.Project` for `project_dir`.
+    """
     ignored = _build_ignored_resources(project_dir)
     project = Project(str(project_dir), ropefolder=None, ignored_resources=ignored)
     project.prefs["prefer_module_from_imports"] = True
@@ -126,7 +134,11 @@ def _with_rope_project(project_dir: Path) -> Iterator[Project]:
 
 
 def _get_top_level_symbols(source: str) -> list[str]:
-    """Parse source and return top-level symbol names."""
+    """Parse source and return top-level symbol names.
+
+    Returns:
+        Names of top-level functions, classes, and assigned variables.
+    """
     try:
         tree = ast.parse(source)
     except SyntaxError:
@@ -148,7 +160,11 @@ def _get_top_level_symbols(source: str) -> list[str]:
 
 
 def _find_symbol_offset(source: str, symbol_name: str) -> int | None:
-    """Find the byte offset of a top-level symbol in source code."""
+    """Find the byte offset of a top-level symbol in source code.
+
+    Returns:
+        Byte offset of `symbol_name`, or None if not found / parse error.
+    """
     try:
         tree = ast.parse(source)
     except SyntaxError:
@@ -201,6 +217,9 @@ def _format_changes(
         dry_run: Whether this is a dry-run preview.
         pre_existing: Paths that existed before the operation. Used in
             non-dry-run mode to distinguish created vs modified files.
+
+    Returns:
+        Multi-line text listing each created/modified path.
     """
     prefix = "[DRY RUN] Would modify" if dry_run else "Modified"
     create_prefix = "[DRY RUN] Would create" if dry_run else "Created"
@@ -248,7 +267,11 @@ def _move_symbol_impl(
     dest_file: str,
     dry_run: bool,
 ) -> str:
-    """Inner implementation of move_symbol — runs inside a subprocess."""
+    """Inner implementation of move_symbol — runs inside a subprocess.
+
+    Returns:
+        Human-readable result, or an error message string.
+    """
     abs_source = project_dir / source_file
     abs_dest = project_dir / dest_file
 
@@ -394,6 +417,9 @@ def _run_rope_subprocess(
     The fix: run rope in a completely separate process with stdin=DEVNULL
     and file-based stdout, using the same execute_command pattern that
     already works for pytest/pylint/mypy in this project.
+
+    Returns:
+        Subprocess result string, or an error message starting with "Error".
     """
     command = [
         sys.executable,
@@ -449,7 +475,11 @@ def move_symbol(
     dry_run: bool = False,
     timeout: int = 120,
 ) -> str:
-    """Move top-level symbols to another module. Updates imports project-wide."""
+    """Move top-level symbols to another module. Updates imports project-wide.
+
+    Returns:
+        Human-readable result, or an error message string.
+    """
     abs_source = project_dir / source_file
     if not abs_source.exists():
         return f"Error: file not found: {source_file}"
@@ -468,7 +498,11 @@ def move_symbol(
 
 
 def _collect_existing_paths(changes: ChangeSet) -> set[str]:
-    """Return the set of resource paths that exist before project.do()."""
+    """Return the set of resource paths that exist before project.do().
+
+    Returns:
+        Resource paths from `changes` that already exist on disk.
+    """
     return {
         change.resource.path for change in changes.changes if change.resource.exists()
     }
@@ -540,7 +574,11 @@ def _rename_symbol_impl(
     new_name: str,
     dry_run: bool,
 ) -> str:
-    """Inner implementation of rename_symbol — runs inside a subprocess."""
+    """Inner implementation of rename_symbol — runs inside a subprocess.
+
+    Returns:
+        Human-readable result, or an error message string.
+    """
     abs_path = project_dir / file_path
     source_text = abs_path.read_text(encoding="utf-8")
 
@@ -579,7 +617,11 @@ def rename_symbol(
     dry_run: bool = False,
     timeout: int = 120,
 ) -> str:
-    """Rename a symbol and update all references project-wide."""
+    """Rename a symbol and update all references project-wide.
+
+    Returns:
+        Human-readable result, or an error message string.
+    """
     abs_path = project_dir / file_path
     if not abs_path.exists():
         return f"Error: file not found: {file_path}"
@@ -609,7 +651,11 @@ def _cleanup_package(abs_pkg: Path, project_dir: Path) -> None:
 
 
 def _is_git_repo(project_dir: Path) -> bool:
-    """Check if project_dir is inside a git repository."""
+    """Check if project_dir is inside a git repository.
+
+    Returns:
+        True if `git rev-parse --git-dir` succeeds in `project_dir`.
+    """
     try:
         result = _subprocess.run(
             ["git", "rev-parse", "--git-dir"],
@@ -623,7 +669,11 @@ def _is_git_repo(project_dir: Path) -> bool:
 
 
 def _is_git_tracked(project_dir: Path, file_path: str) -> bool:
-    """Check if a file is tracked by git (staged or committed)."""
+    """Check if a file is tracked by git (staged or committed).
+
+    Returns:
+        True if `git ls-files --error-unmatch` finds the file (or check fails).
+    """
     try:
         result = _subprocess.run(
             ["git", "ls-files", "--error-unmatch", file_path],
@@ -642,7 +692,11 @@ def _move_module_impl(
     dest_package: str,
     dry_run: bool,
 ) -> str:
-    """Inner implementation of move_module — runs inside a subprocess."""
+    """Inner implementation of move_module — runs inside a subprocess.
+
+    Returns:
+        Human-readable result, or an error message string.
+    """
     abs_dest_pkg = project_dir / dest_package
     abs_source = project_dir / source_module
     created_pkg_for_dry_run = False
@@ -728,7 +782,11 @@ def move_module(
     dry_run: bool = False,
     timeout: int = 120,
 ) -> str:
-    """Move an entire module to a new package. Updates all references."""
+    """Move an entire module to a new package. Updates all references.
+
+    Returns:
+        Human-readable result, or an error message string.
+    """
     abs_source = project_dir / source_module
     if not abs_source.exists():
         return f"Error: file not found: {source_module}"

--- a/src/mcp_tools_py/server.py
+++ b/src/mcp_tools_py/server.py
@@ -19,12 +19,23 @@ T = TypeVar("T")
 
 
 class ToolDecorator(Protocol):
-    def __call__(self, func: Callable[..., T]) -> Callable[..., T]: ...
+    """Protocol for an MCP tool-registration decorator."""
+
+    def __call__(self, func: Callable[..., T]) -> Callable[..., T]:
+        """Register `func` as an MCP tool and return it."""
+        ...
 
 
 class FastMCPProtocol(Protocol):
-    def tool(self) -> ToolDecorator: ...
-    def run(self) -> None: ...
+    """Subset of FastMCP's surface used by ToolServer."""
+
+    def tool(self) -> ToolDecorator:
+        """Return a decorator that registers a tool."""
+        ...
+
+    def run(self) -> None:
+        """Run the MCP server event loop."""
+        ...
 
 
 # Initialize logger
@@ -44,8 +55,7 @@ class ToolServer:
         refactoring_timeout: int = 120,
         vulture_whitelist: str = "vulture_whitelist.py",
     ) -> None:
-        """
-        Initialize the server with the project directory and Python configuration.
+        """Initialize the server with the project directory and Python configuration.
 
         Args:
             project_dir: Path to the project directory to check
@@ -79,7 +89,14 @@ class ToolServer:
         InspectTools().register(self.mcp)
 
     def _resolve_python_executable(self) -> str:
-        """Centralize venv -> python_executable -> sys.executable resolution."""
+        """Centralize venv -> python_executable -> sys.executable resolution.
+
+        Returns:
+            Path to the Python interpreter to use for tool subprocesses.
+
+        Raises:
+            FileNotFoundError: If `venv_path` is set but its python binary is missing.
+        """
         if self.venv_path:
             if os.name == "nt":
                 python = os.path.join(self.venv_path, "Scripts", "python.exe")
@@ -96,7 +113,11 @@ class ToolServer:
             return sys.executable
 
     def _check_tool_availability(self) -> dict[str, bool]:
-        """Check availability of file-existence tools (lint-imports, vulture, ruff, bandit)."""
+        """Check availability of file-existence tools (lint-imports, vulture, ruff, bandit).
+
+        Returns:
+            Mapping of tool name to availability flag.
+        """
         availability: dict[str, bool] = {}
 
         # lint-imports: check via file existence (not subprocess)
@@ -191,7 +212,11 @@ class ToolServer:
         return availability
 
     def _is_tool_available(self, tool_name: str) -> bool:
-        """Check if a tool is available, running subprocess check on first call."""
+        """Check if a tool is available, running subprocess check on first call.
+
+        Returns:
+            True if `python -m <tool_name> --version` succeeds.
+        """
         if tool_name in self._tool_availability:
             return self._tool_availability[tool_name]
         result = execute_command(
@@ -230,8 +255,7 @@ def create_server(
     refactoring_timeout: int = 120,
     vulture_whitelist: str = "vulture_whitelist.py",
 ) -> ToolServer:
-    """
-    Create a new ToolServer instance.
+    """Create a new ToolServer instance.
 
     Args:
         project_dir: Path to the project directory to check

--- a/src/mcp_tools_py/utility_tools.py
+++ b/src/mcp_tools_py/utility_tools.py
@@ -22,6 +22,9 @@ class UtilityTools:
 
             Args:
                 sleep_seconds: Duration to sleep in seconds (0-300, default: 5.0).
+
+            Returns:
+                Confirmation string, or an error message for out-of-range input.
             """
             if sleep_seconds < 0:
                 return "Error: sleep_seconds must be >= 0."

--- a/tools/check_file_size.py
+++ b/tools/check_file_size.py
@@ -1,0 +1,115 @@
+"""Fail if any git-tracked text file exceeds a line-count threshold.
+
+Replacement for ``mcp-coder check file-size`` for use in CI. Exists only
+because the upstream invocation hits the irreducible mcp-coder ↔
+mcp-tools-py URL cycle (chore #107 Section 3). Behaviour matches the
+upstream check: list git-tracked files, count lines (skipping binary),
+ignore allowlisted paths, fail on any non-allowlisted file > max-lines.
+
+Usage:
+    python tools/check_file_size.py --max-lines 750 --allowlist-file .large-files-allowlist
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+
+def load_allowlist(path: Path) -> set[str]:
+    """Read allowlist file; ignore blank lines and ``#`` comments.
+
+    Returns:
+        Allowlisted paths normalised to OS-native separators.
+    """
+    if not path.exists():
+        return set()
+    out: set[str] = set()
+    for line in path.read_text(encoding="utf-8").splitlines():
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        out.add(stripped.replace("/", os.sep).replace("\\", os.sep))
+    return out
+
+
+def list_tracked_files() -> list[str]:
+    """Return git-tracked file paths relative to the repo root.
+
+    Returns:
+        Paths from ``git ls-files`` (always forward-slash from git).
+    """
+    result = subprocess.run(
+        ["git", "ls-files"],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return [line for line in result.stdout.splitlines() if line]
+
+
+def count_lines(file_path: Path) -> int:
+    """Count lines in a file as UTF-8 text.
+
+    Returns:
+        Line count, or ``-1`` if the file isn't valid UTF-8 (binary).
+    """
+    try:
+        with file_path.open(encoding="utf-8") as f:
+            return sum(1 for _ in f)
+    except (UnicodeDecodeError, OSError):
+        return -1
+
+
+def main() -> int:
+    """CLI entry point.
+
+    Returns:
+        ``0`` if all files pass, ``1`` if any non-allowlisted file is too large.
+    """
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--max-lines", type=int, required=True)
+    parser.add_argument("--allowlist-file", type=Path, required=True)
+    args = parser.parse_args()
+
+    allowlist = load_allowlist(args.allowlist_file)
+    tracked = list_tracked_files()
+
+    violations: list[tuple[str, int]] = []
+    checked = 0
+    allowlisted_hits = 0
+    for rel in tracked:
+        normalised = rel.replace("/", os.sep).replace("\\", os.sep)
+        lines = count_lines(Path(rel))
+        if lines < 0:
+            continue
+        checked += 1
+        if lines > args.max_lines:
+            if normalised in allowlist:
+                allowlisted_hits += 1
+            else:
+                violations.append((rel, lines))
+
+    if violations:
+        print(
+            f"File size check failed: {len(violations)} file(s) exceed "
+            f"{args.max_lines} lines"
+        )
+        print()
+        print("Violations:")
+        for path, lines in sorted(violations, key=lambda x: -x[1]):
+            print(f"  - {path}: {lines} lines")
+        return 1
+
+    print(
+        f"File size check passed: {checked} files checked, "
+        f"{allowlisted_hits} allowlisted"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/ruff_check.bat
+++ b/tools/ruff_check.bat
@@ -1,0 +1,14 @@
+@echo off
+REM Check docstrings using ruff (D + DOC rules)
+REM
+REM Usage from cmd.exe: tools\ruff_check.bat
+
+where ruff >nul 2>&1
+if errorlevel 1 (
+    echo ERROR: ruff not found. Install with: uv pip install ruff
+    exit /b 1
+)
+
+echo Checking docstrings with ruff...
+ruff check src tests %*
+exit /b %ERRORLEVEL%

--- a/tools/ruff_check.sh
+++ b/tools/ruff_check.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+# Check docstrings using ruff (D + DOC rules)
+#
+# Usage from Git Bash: ./tools/ruff_check.sh
+
+if ! command -v ruff &> /dev/null; then
+    echo "ERROR: ruff not found. Install with: uv pip install ruff"
+    exit 1
+fi
+
+echo "Checking docstrings with ruff..."
+ruff check src tests "$@"


### PR DESCRIPTION
Follow-up to #199. CI on `main` is currently red on every job — the install step fails with the upstream-mcp-coder URL cycle described in #107 Section 3 (Won't fix as a migration, but the cycle still bites the install). Fixes both angles:

## Summary

1. **`pyproject.toml`** — drop `mcp-coder` from `[project.optional-dependencies].dev` and from `[tool.uv.sources]`. Nothing in `src/` or `tests/` imports `mcp_coder`; the package was only there to make it available alongside `mcp-workspace` for tooling. The cycle (`mcp-coder` pulled by `[dev]` → mcp-coder source-pins `mcp-tools-py` via git → conflict with the local `file://` install) goes away.

2. **`.github/workflows/ci.yml` + `tools/check_file_size.py`** — the `file-size` job ran `uvx --from "git+mcp_coder" --with . mcp-coder check file-size`, which hits the same cycle from a different angle (uvx-isolated install of mcp-coder + `--with .` re-introducing the conflict). Replace with an inline Python script (`git ls-files` + line count + allowlist). Behaviour matches `mcp-coder check file-size` for what CI needs (list violations, fail on > max-lines, ignore allowlist).

3. **`.large-files-allowlist`** — add `src/mcp_tools_py/refactoring/rope_tools.py`. The Section 4 ruff DOC docstring additions in #199 pushed it from 731 → 803 lines. Real refactor belongs to Section 1 of #107.

## Test plan
- [x] `python tools/check_file_size.py --max-lines 750 --allowlist-file .large-files-allowlist` exits 0 locally
- [x] `mcp__mcp-tools-py__run_ruff_check` still green
- [ ] CI: install step succeeds (the actual fix)
- [ ] CI: file-size job green via the new script

Part of #107