### PR TITLE
chore: bump black floor to 26.5.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ dependencies = [
     "vulture>=2.13",
     "ruff>=0.9.0",
     "bandit>=1.7.5",
-    "black>=24.10.0",
+    "black>=26.5.1",
     "isort>=5.13.2",
     "tach>=0.15.0",
     "mcp-coder-utils"


### PR DESCRIPTION
## Summary
- Bumps the minimum `black` version from `24.10.0` to `26.5.1` in `pyproject.toml`.
- Aligns the floor with the current black release so contributors converge on the same formatting output.

## Test plan
- [ ] CI passes (black `--check` on src/tests still green).